### PR TITLE
Proxy Images

### DIFF
--- a/src/app/api/proxy/instagram/[...path]/route.ts
+++ b/src/app/api/proxy/instagram/[...path]/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+    const url = new URL(req.url);
+    const { pathname, searchParams } = url;
+    const newUrl = "https://" + pathname.replace("/api/proxy/instagram/", "") + "?" + searchParams.toString();
+    const proxyRes = await fetch(newUrl);
+    const response = new NextResponse(proxyRes.body);
+    response.headers.set("content-type", proxyRes.headers.get("content-type") ?? "");
+    return response;
+}

--- a/src/components/itemlist.tsx
+++ b/src/components/itemlist.tsx
@@ -20,7 +20,7 @@ const getPreviewProps = (item: Media) => {
   if (isInstagramImage(item)) {
     const resource = findHighestQualityInstagramDisplayResource(item);
     return {
-      src: resource.src,  // TODO: get the highest quality
+      src: "/api/proxy/instagram/" + resource.src.replace("https://", ""),  // TODO: get the highest quality
       url: resource.src,
       width: resource.config_width,
       height: resource.config_height,
@@ -28,7 +28,7 @@ const getPreviewProps = (item: Media) => {
   } else if (isInstagramVideo(item)) {
     const resource = findHighestQualityInstagramDisplayResource(item);
     return {
-      src: resource.src,
+      src: "/api/proxy/instagram/" + resource.src.replace("https://", ""),
       url: item.video_url,
       width: resource.config_width,
       height: resource.config_height,
@@ -36,7 +36,7 @@ const getPreviewProps = (item: Media) => {
   } else if (isThreadsImage(item)) {
     const candidate = findHighestQualityThreadsImage(item);
     return {
-      src: candidate.url,
+      src: "/api/proxy/instagram/" + candidate.url.replace("https://", ""),
       url: candidate.url,
       width: candidate.width,
       height: candidate.height,
@@ -45,7 +45,7 @@ const getPreviewProps = (item: Media) => {
     const imageCandidate = findHighestQualityThreadsImage(item);
     const videoCandidate = findHighestQualityThreadsVideo(item);
     return {
-      src: imageCandidate.url,
+      src: "/api/proxy/instagram/" + imageCandidate.url.replace("https://", ""),
       url: videoCandidate.url,
       width: imageCandidate.width,
       height: imageCandidate.height,
@@ -86,6 +86,7 @@ const ItemCard: FC<ItemCardProps> = ({ item }) => {
           height={height}
           alt="Item Card"
           style={{ objectFit: "contain" }}
+          crossOrigin="anonymous"
           unoptimized
         />
       ) : (
@@ -102,6 +103,7 @@ const ItemCard: FC<ItemCardProps> = ({ item }) => {
           height={height}
           alt="Item Card"
           style={{ objectFit: "contain" }}
+          crossOrigin="anonymous"
           unoptimized
         />
       )}


### PR DESCRIPTION
I enforced high-quality image preview in the last PR, but it broke the image display in the result page. To fix this issue, I use a route handler to proxy the images of Instagram and Threads. Also, the CORS issue of Twitter images is also resolved.